### PR TITLE
Additional changes to the iterator

### DIFF
--- a/COOP/Iterator.c
+++ b/COOP/Iterator.c
@@ -15,7 +15,6 @@ PURE_VIRTUAL(Iterator, next);
 PURE_VIRTUAL(Iterator, get_ref, void** out_ptr);
 PURE_VIRTUAL(Iterator, get_cref, const void** out_ptr);
 PURE_VIRTUAL(Iterator, distance, Iterator* other, ptrdiff_t* out_dist);
-PURE_VIRTUAL(Iterator, reset_begin);
 
 MEM_FUN_IMPL(Iterator, equals, Iterator* other, bool* out_equal)
 {
@@ -75,5 +74,4 @@ BIND(Iterator, get_ref);
 BIND(Iterator, get_cref);
 BIND(Iterator, distance);
 BIND(Iterator, advance);
-BIND(Iterator, reset_begin);
 END_INIT_CLASS(Iterator);

--- a/COOP/Iterator.h
+++ b/COOP/Iterator.h
@@ -17,7 +17,7 @@ void* container_ptr;
 END_DEF(Iterator);
 
 
-FUNCTIONS(Iterator, IteratorCategory category,void *container_ptr);
+FUNCTIONS(Iterator, IteratorCategory category, void* container_ptr);
 
 MEM_FUN_DECL(Iterator, equals, Iterator* other, bool* out_equal);
 MEM_FUN_DECL(Iterator, next);
@@ -26,7 +26,6 @@ MEM_FUN_DECL(Iterator, get_ref, void** out_ptr);
 MEM_FUN_DECL(Iterator, get_cref, const void** out_ptr);
 MEM_FUN_DECL(Iterator, distance, Iterator* other, ptrdiff_t* out_dist);
 MEM_FUN_DECL(Iterator, advance, ptrdiff_t n);
-MEM_FUN_DECL(Iterator, reset_begin);
 
 END_FUNCTIONS(Iterator);
 
@@ -39,19 +38,19 @@ END_FUNCTIONS(Iterator);
 #define ITER_DISTANCE(IT_A, IT_B, OUT_DIST)       MFUN((IT_A), distance), (IT_B), (OUT_DIST) CALL
 #define ITER_ADVANCE(IT, N)                       MFUN((IT), advance), (N) CALL
 #define ITER_CATEGORY(IT)   ((IT)->_category)
-#define ITER_RESET_BEGIN(IT)                      MFUN((IT), reset_begin) CALL
-
 
 #define ITER_CONTINUE do { goto __ITER_CONTINUE_LABEL__;} while(0)
 
 #define ITER_FOR(ElemType, varName, objPtr)          \
 {                                                    \
        bool __eq = 0;                                \
-       Iterator *_it = (Iterator*)&((objPtr)->begin_iter);\
-       Iterator *_end = (Iterator*)&((objPtr)->end_iter); \
+       Iterator *_it=NULL;                           \
+       Iterator *_end=NULL;                          \
+       MFUN(objPtr,begin),&_it CALL;                 \
+       MFUN(objPtr, end), &_end CALL;                \
        FOR (;!(__eq)&&!(IS_BREAKING);) {             \
          ITER_EQUALS(_it,_end,&__eq);                \
-         if (__eq||IS_BREAKING){ITER_RESET_BEGIN(_it); break;}   \
+         if (__eq||IS_BREAKING){break;}              \
          const ElemType *_p_##varName = NULL;        \
          ITER_GET_CREF(_it,&_p_##varName);           \
          ElemType varName = *_p_##varName;           \
@@ -60,6 +59,8 @@ END_FUNCTIONS(Iterator);
             __ITER_CONTINUE_LABEL__: \
             ITER_NEXT(_it);          \
         END_LOOP                     \
+        DESTROY(_it);                \
+	    DESTROY(_end);               \
       }                              \
 }
 

--- a/COOP/vector.h
+++ b/COOP/vector.h
@@ -20,7 +20,6 @@ FUN_OVERRIDE(Iterator, get_ref, void** out_ptr);
 FUN_OVERRIDE(Iterator, get_cref, const void** out_ptr);
 FUN_OVERRIDE(Iterator, distance, Iterator* other, ptrdiff_t* out_dist);
 FUN_OVERRIDE(Iterator, advance, ptrdiff_t n);
-FUN_OVERRIDE(Iterator, reset_begin);
 END_DERIVED_FUNCTIONS(VectorIter);
 
 //////////////////////////////////////////////////////
@@ -31,8 +30,6 @@ MEM_SIZE_T size;
 MEM_SIZE_T capacity;
 MEM_SIZE_T elementSize;
 char* data;
-VectorIter begin_iter;  
-VectorIter end_iter;
 END_DEF(GenericVector);
 
 FUNCTIONS(GenericVector, MEM_SIZE_T dataTypeSize);
@@ -72,6 +69,8 @@ MEM_FUN_DECL(GenericVector, pop_back_float, float* val);
 MEM_FUN_DECL(GenericVector, pop_back_objSPtr, objSPtr* val);
 
 MEM_FUN_DECL(GenericVector, zero_all);
+MEM_FUN_DECL(GenericVector, begin, Iterator** out_it);
+MEM_FUN_DECL(GenericVector, end, Iterator** out_it);
 
 END_FUNCTIONS(GenericVector);
 
@@ -93,6 +92,8 @@ MEM_FUN_DECL(Vector_ ##type, resize, MEM_SIZE_T new_capacity); \
 MEM_FUN_DECL(Vector_ ##type, size, MEM_SIZE_T * out_size); \
 MEM_FUN_DECL(Vector_ ##type, zero_all); \
 MEM_FUN_DECL(Vector_ ##type, print); \
+MEM_FUN_DECL(Vector_ ##type, begin, VectorIter* out_it); \
+MEM_FUN_DECL(Vector_ ##type, end, VectorIter* out_it); \
 END_DERIVED_FUNCTIONS(Vector_ ##type);
 
 DECLARE_SPECIFIC_VECTOR_TYPE(int);

--- a/COOP/vector.h
+++ b/COOP/vector.h
@@ -69,8 +69,8 @@ MEM_FUN_DECL(GenericVector, pop_back_float, float* val);
 MEM_FUN_DECL(GenericVector, pop_back_objSPtr, objSPtr* val);
 
 MEM_FUN_DECL(GenericVector, zero_all);
-MEM_FUN_DECL(GenericVector, begin, Iterator** out_it);
-MEM_FUN_DECL(GenericVector, end, Iterator** out_it);
+MEM_FUN_DECL(GenericVector, begin, Iterator **out_it);
+MEM_FUN_DECL(GenericVector, end, Iterator **out_it);
 
 END_FUNCTIONS(GenericVector);
 
@@ -92,8 +92,8 @@ MEM_FUN_DECL(Vector_ ##type, resize, MEM_SIZE_T new_capacity); \
 MEM_FUN_DECL(Vector_ ##type, size, MEM_SIZE_T * out_size); \
 MEM_FUN_DECL(Vector_ ##type, zero_all); \
 MEM_FUN_DECL(Vector_ ##type, print); \
-MEM_FUN_DECL(Vector_ ##type, begin, VectorIter* out_it); \
-MEM_FUN_DECL(Vector_ ##type, end, VectorIter* out_it); \
+MEM_FUN_DECL(Vector_ ##type, begin, Iterator **out_it); \
+MEM_FUN_DECL(Vector_ ##type, end, Iterator **out_it); \
 END_DERIVED_FUNCTIONS(Vector_ ##type);
 
 DECLARE_SPECIFIC_VECTOR_TYPE(int);

--- a/UnitTestC/vectorUnitTest.c
+++ b/UnitTestC/vectorUnitTest.c
@@ -151,8 +151,10 @@ TEST_FUN_IMPL(VectorTest, nextPrev_MoveOK_andPrevThrowsAtBegin)
 	} END_LOOP;
 	
 
-	Iterator* it = (Iterator*)&(vec._base.begin_iter);
-	Iterator* end = (Iterator*)&(vec._base.end_iter);
+	Iterator* it = NULL;                           
+	Iterator* end = NULL;                          
+	MFUN(&vec, begin), & it CALL;               
+	MFUN(&vec, end), & end CALL;                
 
 	/* prev at begin must throw */
 	EXPECT_THROW;
@@ -180,7 +182,8 @@ TEST_FUN_IMPL(VectorTest, getRef_getCref_PointsToCurrent)
 		MFUN(&vec, push_back), i CALL;
 	} END_LOOP;
 
-	Iterator* it = (Iterator*)&(vec._base.begin_iter);
+	Iterator* it = NULL;
+	MFUN(&vec, begin), & it CALL;
 
 	/* at begin -> value 0 */
 	const void* cptr = NULL;
@@ -203,8 +206,10 @@ TEST_FUN_IMPL(VectorTest, distance_And_Advance_Bounds)
 		MFUN(&vec, push_back), i CALL;
 	} END_LOOP;
 
-	Iterator* b = (Iterator*)&(vec._base.begin_iter);
-	Iterator* e = (Iterator*)&(vec._base.end_iter);
+	Iterator* b = NULL;                          
+	Iterator* e = NULL;                         
+	MFUN(&vec, begin), & b CALL;               
+	MFUN(&vec, end), & e CALL;                
 
 	/* distance(begin, end) == size */
 	ptrdiff_t dist = -999;


### PR DESCRIPTION

**Removed** the internal **begin_iter** and **end_iter** member variables from containers.

**Added begin() and end() functions** instead, to provide iterators dynamically.

This makes the API cleaner and closer to C++ style iteration.

Removed the now redundant reset_begin function.