### PR TITLE
Use MEM_SIZE_T=int for tests

### DIFF
--- a/COOP/CMakeLists.txt
+++ b/COOP/CMakeLists.txt
@@ -62,6 +62,23 @@ set(ALL_FILES
 ################################################################################
 add_library(${PROJECT_NAME} STATIC ${ALL_FILES})
 
+#Creates a wide version of the COOP library for benchmarks that need larger index types (MEM_SIZE_T = int)
+add_library(COOP_testing STATIC ${ALL_FILES})
+
+set_target_properties(COOP_testing PROPERTIES OUTPUT_NAME "COOP_testing")
+
+
+#Ensures both library versions (COOP and COOP_testing) share the same header search paths
+target_include_directories(COOP_testing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+#Allows testing and benchmarks with larger data sizes by redefining MEM_SIZE_T to int
+target_compile_definitions(COOP_testing PUBLIC MEM_SIZE_T=int)
+
+# Keeps Linux builds clean by silencing harmless pointer-type warnings when compiling the wide version
+if(UNIX AND NOT APPLE)
+ target_compile_options(COOP_testing PRIVATE -Wno-incompatible-pointer-types)
+endif()
+
 set(ROOT_NAMESPACE COOP)
 
 

--- a/COOP/iCache.h
+++ b/COOP/iCache.h
@@ -3,7 +3,9 @@
 
 #include "Object.h"
 
-typedef unsigned short MEM_SIZE_T;
+#ifndef MEM_SIZE_T
+#define MEM_SIZE_T unsigned short
+#endif
 
 DEF_CLASS(ICache);
 END_DEF(ICache);

--- a/UnitTestC/CMakeLists.txt
+++ b/UnitTestC/CMakeLists.txt
@@ -127,6 +127,7 @@ elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x86")
         "_UNICODE"
     )
 endif()
+target_compile_definitions(${PROJECT_NAME} PRIVATE MEM_SIZE_T=int)
 
 ################################################################################
 # Compile and link options
@@ -196,6 +197,6 @@ endif()
 ################################################################################
 # Link with other targets.
 target_link_libraries(${PROJECT_NAME} PRIVATE
-    COOP
+    COOP_testing
 )
 

--- a/UnitTestC/listUnitTest.c
+++ b/UnitTestC/listUnitTest.c
@@ -7,6 +7,7 @@
 
 TEST_FUN_IMPL(ListTest, push_back_SanityTest)
 {
+    FUN(init_global_memory) 0, HEAP_BASED_MEMORY CALL;
     CREATE(List_int, lst_int) CALL;
     CREATE(List_char, lst_char) CALL;
     int numElements = 54;


### PR DESCRIPTION
Added a new COOP_testing target compiled with MEM_SIZE_T=int to allow tests and benchmarks to handle large data sets.

Updated COOP’s CMake so tests use the same source files compiled with MEM_SIZE_T=int, ensuring proper linkage.

Defined MEM_SIZE_T as short only if not predefined, keeping compatibility for regular builds.

In the List test, switched to heap allocation to remove size limitations.

Overall, test and benchmark builds are now consistent and support large structures.